### PR TITLE
Update upload-pages-artifact to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
         echo "::endgroup::"
 
     - name: 'upload'
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with: 
         path: ${{ inputs.path }}
 


### PR DESCRIPTION
As of January 30, 2025, v3 of `actions/upload-pages-artifact` has been deprecated. Github is requiring an upgrade to v4 which is blocking deploys to pages. 

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Github notes a few breaking changes with v4: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

