### PR TITLE
Update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
         echo "::endgroup::"
 
     - name: 'upload'
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-artifact@v4
       with: 
         path: ${{ inputs.path }}
 


### PR DESCRIPTION
update to use 
actions/upload-artifact@v4

deprecated version of `actions/upload-artifact: v3`. 

source https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/